### PR TITLE
docs: add feature-request template

### DIFF
--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,29 @@
+name: Feature request
+description: Suggest a new feature or enhancement.
+title: "[Feature]: "
+labels: ["enhancement"]
+body:
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem you're trying to solve
+      description: What's the pain point or use case behind this request?
+    validations:
+      required: true
+  - type: textarea
+    id: solution
+    attributes:
+      label: Suggested solution
+      description: How would you like this to work?
+    validations:
+      required: true
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: Have you tried other approaches or workarounds?
+  - type: textarea
+    id: context
+    attributes:
+      label: Additional context
+      description: Anything else that might be useful â€” screenshots, examples, related issues.


### PR DESCRIPTION
Adds a structured feature-request template. Nice complement to the bug-report form â€” encourages contributors to explain the underlying problem before jumping to a proposed solution.